### PR TITLE
Missing quote for install.packages()

### DIFF
--- a/modules/module2_managingR.Rmd
+++ b/modules/module2_managingR.Rmd
@@ -65,7 +65,7 @@ install.packages('fields')
 That should work without specifying the repository from which to download the package (though sometimes you will be given a menu of repositories from which to select) but sometimes you'll get errors indicating a package is not available for your version of R if you don't include an explicit repository. In this case you'll likely need to use a repository that uses `http` rather than `https`, e.g.,
 
 ```{r eval = FALSE}
-install.packages('fields', repos = 'http://cran.cnr.berkeley.edu) 
+install.packages('fields', repos = 'http://cran.cnr.berkeley.edu') 
 ```
 
 If you're on a network and are not the administrator of the machine, you may need to explicitly tell R to install it in a directory you are able to write in:


### PR DESCRIPTION
Quick typo fix in the Rmd file
